### PR TITLE
switch from wget to curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ boot2docker.box: boot2docker.iso
 	packer build template.json
 
 boot2docker.iso:
-	wget https://github.com/steeve/boot2docker/releases/download/v0.3.0/boot2docker.iso
+	curl -LO https://github.com/steeve/boot2docker/releases/download/v0.3.0/boot2docker.iso
 
 clean:
 	rm -f boot2docker.iso


### PR DESCRIPTION
Since `wget` isn’t installed on OS X by default, I’ve replaced it with an equivalent `curl` command.
