### PR TITLE
Format the hard drive so that boot2docker auto-mounts it

### DIFF
--- a/template.json
+++ b/template.json
@@ -20,6 +20,11 @@
         "shutdown_command": "sudo poweroff"
     }],
 
+    "provisioners": [{
+      "type": "shell",
+      "inline": ["mkfs.ext4 -F -L boot2docker-data /dev/sda"]
+    }],
+
     "post-processors": [{
         "type": "vagrant",
         "include": ["boot2docker-vagrant.iso"],


### PR DESCRIPTION
See https://github.com/steeve/boot2docker#persist-data

Relates to #19
