### PR TITLE
Add note to README.md about DOCKER_HOST on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ and `vagrant up` as usual! Or, if you don't want to leave your terminal:
 
     $ vagrant init boot2docker https://github.com/mitchellh/boot2docker-vagrant-box/releases/download/v0.5.4/boot2docker_virtualbox.box
     $ vagrant up
+    
+On OS X, to use the docker client, simply `export DOCKER_HOST=localhost`. You should then be able to to run `docker version` from the host.
 
 ![Vagrant Up Boot2Docker](https://raw.github.com/mitchellh/boot2docker-vagrant-box/master/readme_image.gif)
 


### PR DESCRIPTION
Indicate that you can get the native OS X docker client to work by exporting DOCKER_HOST correctly.

Closes #12
