### PR TITLE
add note about virtualbox version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ do so in seconds.
 To build the box, first install the following prerequisites:
 
   * [Packer](http://www.packer.io) (at least version 0.5.1)
-  * [VirtualBox](http://www.virtualbox.org) or VMware
+  * [VirtualBox](http://www.virtualbox.org) (at least version 4.3) or VMware
   * [Vagrant](http://www.vagrantup.com)
 
 Then follow the steps:


### PR DESCRIPTION
Issues #3 and #11 suggest that the scripts do not support old version of VirtualBox < 4.3. This version requirement should be noted up front in the readme to avoid others getting stuck on this issue (as I did just now).
