### PR TITLE
Added support of Parallels provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,4 +15,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.customize ["modifyvm", :id, "--memory", "1500"]
   end
+
+  config.vm.provider "parallels" do |v, override|
+    override.vm.box = "parallels/ubuntu-12.04"
+    v.memory = 1500
+  end
 end

--- a/template.json
+++ b/template.json
@@ -18,6 +18,15 @@
         "ssh_username": "docker",
         "ssh_password": "tcuser",
         "shutdown_command": "sudo poweroff"
+    }, {
+        "type": "parallels-iso",
+        "iso_url": "boot2docker-vagrant.iso",
+        "iso_checksum_type": "none",
+        "boot_wait": "5s",
+        "guest_os_distribution": "linux",
+        "ssh_username": "docker",
+        "ssh_password": "tcuser",
+        "shutdown_command": "sudo poweroff"
     }],
 
     "provisioners": [{

--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -28,4 +28,17 @@ Vagrant.configure("2") do |config|
       v.vmx["ide1:0.deviceType"] = "cdrom-image"
     end
   end
+
+  config.vm.provider "parallels" do |v|
+    v.customize "pre-boot", [
+      "set", :id,
+      "--device-set", "cdrom0",
+      "--enable", "--connect",
+      "--image", File.expand_path("../boot2docker-vagrant.iso", __FILE__)
+    ]
+    v.customize "pre-boot", [
+      "set", :id,
+      "--device-bootorder", "cdrom0 hdd0"
+    ]
+  end
 end


### PR DESCRIPTION
Related to GH-39

Since Packer is supporting Parallels now, I've made this template compatible with `parallels-iso` builder.
I've also tested template and builded a box-file for `parallels` provider: http://download.parallels.com/desktop/vagrant/boot2docker.box

@mitchellh, you can add this link to your box on [Vagrantcloud](https://vagrantcloud.com/mitchellh/boot2docker), I think it will be very useful for our users.
