### PR TITLE
Allow forwarded_port 4243 to be overridden; Listen on 127.0.0.1 only by ...

### DIFF
--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   # Expose the Docker port
-  config.vm.network "forwarded_port", guest: 4243, host: 4243
+  config.vm.network "forwarded_port", guest: 4243, host: 4243, host_ip: "127.0.0.1", id: "docker"
 
   # Attach the ISO
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
...default.

The Docker port allows arbitrary remote code execution inside the VM, so
we don't want that turned on by default.

Unfortunately, this is still going to be a problem for users of the
vmware_fusion provider, since it apparently ignores the :host_ip
parameter:

```
https://github.com/mitchellh/vagrant/issues/3916
```

Adding :id => "docker" allows downstream users of the box to disable the
port-forward using something like this in their Vagrantfile:

```
config.vm.network "forwarded_port", guest: 4243, host: 4243, id: "docker", disabled: true
```
