### PR TITLE
Missing quote character in build-iso.sh

### DIFF
--- a/build-iso.sh
+++ b/build-iso.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.1.1/boot2docker.iso
+B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.1.1/boot2docker.iso"
 apt-get -y update
 apt-get install -y genisoimage
 


### PR DESCRIPTION
I was receiving:

```
./build-iso.sh: line 54: unexpected EOF while looking for matching `"'
```
