### PR TITLE
Update boot2docker ISO download to v1.1.2

### DIFF
--- a/build-iso.sh
+++ b/build-iso.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.1.1/boot2docker.iso"
+B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v.1.1.2/boot2docker.iso"
 apt-get -y update
 apt-get install -y genisoimage
 


### PR DESCRIPTION
The `boot2docker` tag is incorrect on purpose. It contains a period between the `v` and major version number.
