### PR TITLE
update the iso to v1.2.0 for various fixes

### DIFF
--- a/build-iso.sh
+++ b/build-iso.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.1.1/boot2docker.iso"
+B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.2.0/boot2docker.iso"
 apt-get -y update
 apt-get install -y genisoimage
 


### PR DESCRIPTION
@SvenDowideit released this 12 hours ago

Docker v1.2.0
Linux Kernel 3.16.1
Add /etc/os-release file version and distro info.
Attempt to sync the clock better
Add /var/lib/boot2docker/profile for customising Docker daemon settings
Speed up SSH by turning off DNS check
Log boot output to /var/log/boot2docker.log
Add infrastructure to allow Docker TLS Socket
Fix devmapper Docker test
Fix fix 'sudo -i and sudo su -'
