### PR TITLE
Now works with boot2docker 1.3.0 on virtualbox (not tested with other pr...

### DIFF
--- a/build-iso.sh
+++ b/build-iso.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.2.0/boot2docker.iso"
+B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.3.0/boot2docker.iso"
 
 apt-get -y update
 apt-get install -y genisoimage

--- a/template.json
+++ b/template.json
@@ -4,7 +4,7 @@
         "iso_url": "boot2docker-vagrant.iso",
         "iso_checksum_type": "none",
         "boot_wait": "5s",
-        "guest_additions_mode": "disable",
+        "guest_additions_mode": "attach",
         "guest_os_type": "Linux_64",
         "ssh_username": "docker",
         "ssh_password": "tcuser",


### PR DESCRIPTION
Hi!

Now works with boot2docker 1.3.0 on virtualbox (not tested with other providers).

Should close #65 

I have the following in my vagrantfile wish the docker providers use:

```
 config.vm.provider "virtualbox" do |v|
    # On VirtualBox, we don't have guest additions or a functional vboxsf
    # in TinyCore Linux, so tell Vagrant that so it can be smarter.
#    v.check_guest_additions = false
#    v.functional_vboxsf     = false
    v.customize ["modifyvm", :id, "--memory", "4096"]
  end
```

Sincerely 
Mikael
