### PR TITLE
Adding auto correction for the docker NAT port 

### DIFF
--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   # Expose the Docker port
-  config.vm.network "forwarded_port", guest: 2375, host: 2375, host_ip: "127.0.0.1", id: "docker"
+  config.vm.network "forwarded_port", guest: 2375, host: 2375, host_ip: "127.0.0.1", auto_correct: true, id: "docker"
 
   # Attach the ISO
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
Hi !

Adding the auto_correct option will protect against these cases :
- A docker daemon is running on the same host running the VM
- When running multiples instance of the VM (i met this issue when trying to simulate a multi docker host setup)
