### PR TITLE
Enabling the default vagrant share while boot2docker 1.3.0 embed vboxsf

### DIFF
--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -2,9 +2,6 @@ Vagrant.configure("2") do |config|
   config.ssh.shell = "sh"
   config.ssh.username = "docker"
 
-  # Disable synced folders because guest additions aren't available
-  config.vm.synced_folder ".", "/vagrant", disabled: true
-
   # Expose the Docker port
   config.vm.network "forwarded_port", guest: 2375, host: 2375, host_ip: "127.0.0.1", auto_correct: true, id: "docker"
 


### PR DESCRIPTION
Here is the official documentation from b2d : https://github.com/boot2docker/boot2docker#virtualbox-guest-additions.

We just have to remove the line which was disabling the default /vagrant share.