### PR TITLE
Packer 7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ packer_cache/
 *.box
 b2d.iso
 boot2docker-vagrant.iso
+output*

--- a/template.json
+++ b/template.json
@@ -26,7 +26,8 @@
         "guest_os_distribution": "linux",
         "ssh_username": "docker",
         "ssh_password": "tcuser",
-        "shutdown_command": "sudo poweroff"
+        "shutdown_command": "sudo poweroff",
+        "parallels_tools_mode": "disable"
     }],
 
     "provisioners": [{


### PR DESCRIPTION
Hi, due to some errors using packer 0.7.2, i disabled the parallels tools while they don't seem to be needed (correct me if i'm wrong) ?
The goal was only to make packer build running.

I added a line to the gitignore for output folder generated from packer.


For history :
* The error :
```
C:\workspace\dduportal\boot2docker-vagrant-box>packer -v
Packer v0.7.2

C:\workspace\dduportal\boot2docker-vagrant-box>packer build -parallel=false template.json
virtualbox-iso output will be in this color.
vmware-iso output will be in this color.
parallels-iso output will be in this color.

Warnings for build 'virtualbox-iso':

* A checksum type of 'none' was specified. Since ISO files are so big,
a checksum is highly recommended.

Warnings for build 'vmware-iso':

* A checksum type of 'none' was specified. Since ISO files are so big,
a checksum is highly recommended.

1 error(s) occurred:

* parallels_tools_flavor must be specified.
```

* The packer documentation refering to the parallels builder, used to disable tools : https://github.com/mitchellh/packer/blob/master/website/source/docs/builders/parallels-iso.html.markdown