### PR TITLE
Adding docker SSL tcp port

### DIFF
--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -5,8 +5,9 @@ Vagrant.configure("2") do |config|
   # Disable synced folders because guest additions aren't available
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
-  # Expose the Docker port
+  # Expose the Docker ports (non secured AND secured)
   config.vm.network "forwarded_port", guest: 2375, host: 2375, host_ip: "127.0.0.1", auto_correct: true, id: "docker"
+  config.vm.network "forwarded_port", guest: 2376, host: 2376, host_ip: "127.0.0.1", auto_correct: true, id: "docker-ssl"
 
   # Attach the ISO
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
This PR add the brand-new SSL port in the NAT redirection, because when the docker client is used outside the box, since 1.3.0, there is an ecnrypted link.

I didn't delete the old 3275 for ascendant compatibility with existing setups.