### PR TITLE
Use headless Virtualbox when building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ prepare: clean boot2docker-vagrant.iso
 boot2docker_virtualbox.box: boot2docker-vagrant.iso
 	packer build -only=virtualbox-iso template.json
 
-boot2docker-vagrant.iso:
+boot2docker-vagrant.iso: build-iso.sh
 	vagrant up
 	vagrant ssh -c 'cd /vagrant && sudo ./build-iso.sh'
 	vagrant destroy --force

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ build: boot2docker-vagrant.iso
 
 prepare: clean boot2docker-vagrant.iso
 
+boot2docker_virtualbox.box: boot2docker-vagrant.iso
+	packer build -only=virtualbox-iso template.json
+
 boot2docker-vagrant.iso:
 	vagrant up
 	vagrant ssh -c 'cd /vagrant && sudo ./build-iso.sh'

--- a/build-iso.sh
+++ b/build-iso.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.3.0/boot2docker.iso"
+B2D_URL="https://github.com/boot2docker/boot2docker/releases/download/v1.4.0/boot2docker.iso"
 
 apt-get -y update
 apt-get install -y genisoimage

--- a/template.json
+++ b/template.json
@@ -8,7 +8,8 @@
         "guest_os_type": "Linux_64",
         "ssh_username": "docker",
         "ssh_password": "tcuser",
-        "shutdown_command": "sudo poweroff"
+        "shutdown_command": "sudo poweroff",
+        "headless": true
     }, {
         "type": "vmware-iso",
         "iso_url": "boot2docker-vagrant.iso",


### PR DESCRIPTION
Headless simplifies building images in batch builds.