### PR TITLE
Use headless Virtualbox when building.

### DIFF
--- a/template.json
+++ b/template.json
@@ -8,7 +8,8 @@
         "guest_os_type": "Linux_64",
         "ssh_username": "docker",
         "ssh_password": "tcuser",
-        "shutdown_command": "sudo poweroff"
+        "shutdown_command": "sudo poweroff",
+        "headless": true
     }, {
         "type": "vmware-iso",
         "iso_url": "boot2docker-vagrant.iso",


### PR DESCRIPTION
Headless simplifies building images in batch builds.

New PR attempt, from a branch this time.
