### PR TITLE
Update to boot2docker 1.7.0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ packer_cache/
 *.box
 b2d.iso
 boot2docker-vagrant.iso
+rsync.tcz

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ build: boot2docker-vagrant.iso
 
 prepare: clean boot2docker-vagrant.iso
 
-boot2docker-vagrant.iso:
+boot2docker-vagrant.iso: build-iso.sh
 	vagrant up
-	vagrant ssh -c 'cd /vagrant && sudo ./build-iso.sh'
+	vagrant ssh -c "cd /vagrant && sudo /bin/bash -c \"EXTRA_ARGS='${EXTRA_ARGS}' ./build-iso.sh\""
 	vagrant destroy --force
 
 clean:

--- a/README.md
+++ b/README.md
@@ -49,5 +49,8 @@ $ packer build template.json
 ...
 ```
 
+Additional docker arguments, such as adding an insecure repository, can be done by setting the `EXTRA_ARGS` environment variable 
+when running build-iso.sh.
+
 You can restrict only VirtualBox, VMware, or Parallels by specifying the `-only` flag
 to Packer.


### PR DESCRIPTION
A fairly complex change due to the inclusion of TLS by default and a switch to 64 bit user space in TCL.  The following patch has 3 major components:
- Disable TLS by default through the generation of a boot2docker profile file
- Automatic installation of a non-repo based rsync tcz
- Support for passing on EXTRA_ARGS to allow for adding insecure repositories during image creation

We should probably figure out a better approach for the rsync issue, however.
